### PR TITLE
WIP migration to RC2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val diodeReact = project
   .settings(
     name := "diode-react",
     libraryDependencies ++= Seq(
-      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC1"
+      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC2"
     ),
     scalacOptions ++= sourceMapSetting.value
   )

--- a/diode-react/src/main/scala/diode/react/ReactConnector.scala
+++ b/diode-react/src/main/scala/diode/react/ReactConnector.scala
@@ -116,7 +116,7 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
       }
 
       private def changeHandler(cursor: ModelRO[S]): Unit = {
-        val isMounted = t.isMounted
+        val isMounted = t.isMounted.map(_.getOrElse(false))
         val stateHasChanged = t.state.map(state => modelReader =!= state)
         (isMounted && stateHasChanged).map {
           case true => t.setState(modelReader()).runNow()
@@ -127,7 +127,7 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
       def render(s: S, compB: ModelProxy[S] => VdomElement) = wrap(modelReader)(compB)
     }
 
-    ScalaComponent.build[ModelProxy[S] => VdomElement]("DiodeWrapper")
+    ScalaComponent.builder[ModelProxy[S] => VdomElement]("DiodeWrapper")
       .initialState(modelReader())
       .renderBackend[Backend]
       .componentWillMount(_.backend.willMount)


### PR DESCRIPTION
Hey, Thanks for your work upgrading Diode to RC1.  Here is a work in progress migration to RC2.  it's working for me so far.

The defaulting to `false` is a blind assumption.  Please question this.
`val isMounted = t.isMounted.map(_.getOrElse(false))`
