### PR TITLE
Upgrade to ScalaJS-ReactJS 1.0.0-RC2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 [![Gitter](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/ochrons/diode)
 [![Build Status](https://travis-ci.org/ochrons/diode.svg?branch=master)](https://travis-ci.org/ochrons/diode)
-[![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.13.svg)](https://www.scala-js.org)
+[![Scala.js](https://www.scala-js.org/assets/badges/scalajs-0.6.14.svg)](https://www.scala-js.org)
 
 Diode is a Scala/Scala.js library for managing immutable application state with unidirectional data flow. It is heavily
 influenced and inspired by [Flux](https://facebook.github.io/flux/) and

--- a/build.sbt
+++ b/build.sbt
@@ -160,7 +160,7 @@ lazy val diodeReact = project
   .settings(
     name := "diode-react",
     libraryDependencies ++= Seq(
-      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC1"
+      "com.github.japgolly.scalajs-react" %%% "core" % "1.0.0-RC2"
     ),
     scalacOptions ++= sourceMapSetting.value
   )

--- a/diode-react/src/main/scala/diode/react/ReactConnector.scala
+++ b/diode-react/src/main/scala/diode/react/ReactConnector.scala
@@ -100,7 +100,7 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
   def connect[S <: AnyRef](modelReader: ModelRO[S], key: js.UndefOr[js.Any] = js.undefined)(
       implicit feq: FastEq[_ >: S]): ReactConnectProxy[S] = {
 
-    class Backend(t: BackendScope[ModelProxy[S] => VdomElement, S]) {
+    class Backend(t: BackendScope[ReactConnectProps[S], S]) {
       private var unsubscribe = Option.empty[() => Unit]
 
       def willMount = {
@@ -119,8 +119,8 @@ trait ReactConnector[M <: AnyRef] { circuit: Circuit[M] =>
         val isMounted = t.isMounted.map(_.getOrElse(false))
         val stateHasChanged = t.state.map(state => modelReader =!= state)
 
-        def updateState(really: Boolean): Callback =
-          Callback.when(really)(t.setState(modelReader()))
+        def updateState(shouldUpdate: Boolean): Callback =
+          Callback.when(shouldUpdate)(t.setState(modelReader()))
 
         ((isMounted && stateHasChanged) >>= updateState).runNow()
       }

--- a/diode-react/src/main/scala/diode/react/package.scala
+++ b/diode-react/src/main/scala/diode/react/package.scala
@@ -1,9 +1,10 @@
 package diode
 
 import japgolly.scalajs.react._
-import japgolly.scalajs.react.component.Generic.Unmounted
+import japgolly.scalajs.react.component.Generic.UnmountedWithRoot
 import japgolly.scalajs.react.vdom.VdomElement
 
 package object react {
-  type ReactConnectProxy[A] = CtorType.Props[ModelProxy[A] => VdomElement, Unmounted[ModelProxy[A] => VdomElement, _]]
+  type ReactConnectProps[A] = ModelProxy[A] => VdomElement
+  type ReactConnectProxy[A] = CtorType.Props[ReactConnectProps[A], UnmountedWithRoot[ReactConnectProps[A], _, _, _]]
 }

--- a/project/Version.scala
+++ b/project/Version.scala
@@ -1,3 +1,3 @@
 object Version {
-  val library = "1.1.1"
+  val library = "1.1.2-SNAPSHOT"
 }


### PR DESCRIPTION
Took the liberty of working over your initial PR for Diode and upgrading it to scalajs-react 1.0.0-RC2, which was published today.

In the new version the `ScalaComponent.build` has been renamed to `ScalaComponent.builder` whilst `BackendScope.isMonted` now returns an `CallbackTo[Option[Boolean]]` instead of `CallbackTo[Boolean]`:
https://github.com/japgolly/scalajs-react/blob/master/doc/changelog/1.0.0-RC.md

Regardless of that, being the `ReactConnector` a Scala component, we can fallback to a `CallbackTo[Boolean]` quite safely.

I'm also including a small rewrite of the `changeHandler` which was looking a bit awkward with a pattern match on a `Boolean` and the double `runNow()`. The new version of it uses monadic composition via a helper local function.